### PR TITLE
Support promesa/map and promesa/mapcat ops

### DIFF
--- a/src/sci_configs/funcool/promesa.cljs
+++ b/src/sci_configs/funcool/promesa.cljs
@@ -110,6 +110,8 @@
    'let (sci/copy-var let pns)
    'all (sci/copy-var p/all pns)
    'any (sci/copy-var p/any pns)
+   'map (sci/copy-var p/map pns)
+   'mapcat (sci/copy-var p/mapcat pns)
    'resolved (sci/copy-var p/resolved pns)
    'rejected (sci/copy-var p/rejected pns)
    'deferred (sci/copy-var p/deferred pns)


### PR DESCRIPTION
Found myself needing this when implementing a recursive readdir function with fs/promises.readdir. 

Was able to work around it but p/mapcat would be cleaner I feel:

```cljs
(defn readdir
  [dirpath]
  (p/->> (fs/readdir dirpath #js {:withFileTypes true})
         (map (fn [dirent]
                (let [filepath (.join path dirpath (.-name dirent))]
                  (cond (.isDirectory dirent)
                        (readdir filepath)

                        (.isFile dirent)
                        [filepath]

                        :else
                        []))
                ))
         (p/all)
         (reduce #(into %1 %2) [])))
```